### PR TITLE
cross-browser solution

### DIFF
--- a/javascript/keyboard.js
+++ b/javascript/keyboard.js
@@ -5,8 +5,7 @@ btn.addEventListener("click", function(){ drawModule.init();});
 
 	document.onkeydown = function(event) {
 
-        keyCode = window.event.keyCode; 
-        keyCode = event.keyCode;
+        keyCode = event.which||event.keyCode; 
 
         switch(keyCode) {
         


### PR DESCRIPTION
The code has been made compatible with Firefox browser. The onkeypress keyCode does not work with Firefox. The error has been resolved. Fixes #1 .